### PR TITLE
feat: omit backend encryption of e2e messages

### DIFF
--- a/src/test/java/de/caritas/cob/messageservice/api/controller/MessageControllerE2EIT.java
+++ b/src/test/java/de/caritas/cob/messageservice/api/controller/MessageControllerE2EIT.java
@@ -359,9 +359,9 @@ public class MessageControllerE2EIT {
     givenAuthenticatedUser();
     givenRocketChatSystemUser();
     var rcGroupId = RandomStringUtils.randomAlphabetic(16);
-    givenSuccessfulSendMessageResponse("e2e", rcGroupId);
+    givenSuccessfulSendMessageResponse("p", rcGroupId);
     givenAMasterKey();
-    MessageDTO encryptedMessage = createMessage("enc.secret_message", "e2e");
+    MessageDTO encryptedMessage = createMessage("enc.secret_message", "p");
 
     mockMvc.perform(
             post("/messages/new")
@@ -380,7 +380,7 @@ public class MessageControllerE2EIT {
     var sendMessageRequest = body.getMessage();
     assertThat(sendMessageRequest.getRid()).isEqualTo(rcGroupId);
     assertThat(sendMessageRequest.getAlias()).isNull();
-    assertThat(sendMessageRequest.getT()).isEqualTo("e2e");
+    assertThat(sendMessageRequest.getT()).isEqualTo("p");
     assertThat(sendMessageRequest.getMsg()).startsWith("enc:");
   }
 
@@ -391,8 +391,8 @@ public class MessageControllerE2EIT {
     givenAuthenticatedUser();
     givenRocketChatSystemUser();
     var rcGroupId = RandomStringUtils.randomAlphabetic(16);
-    givenSuccessfulSendMessageResponse("e2e", rcGroupId);
-    var encMessageWithOrg = createMessage("enc.secret_message", "e2e")
+    givenSuccessfulSendMessageResponse("p", rcGroupId);
+    var encMessageWithOrg = createMessage("enc.secret_message", "p")
         .org("plain text message");
     givenEncryptionCapturing(encMessageWithOrg.getMessage(), encMessageWithOrg.getOrg());
 
@@ -413,7 +413,7 @@ public class MessageControllerE2EIT {
     var sendMessageRequest = body.getMessage();
     assertThat(sendMessageRequest.getRid()).isEqualTo(rcGroupId);
     assertThat(sendMessageRequest.getAlias()).isNull();
-    assertThat(sendMessageRequest.getT()).isEqualTo("e2e");
+    assertThat(sendMessageRequest.getT()).isEqualTo("p");
     assertThat(sendMessageRequest.getMsg()).isEqualTo("encCameIn");
     assertThat(sendMessageRequest.getOrg()).isEqualTo("plainCameIn");
   }

--- a/src/test/java/de/caritas/cob/messageservice/api/service/DraftMessageServiceIT.java
+++ b/src/test/java/de/caritas/cob/messageservice/api/service/DraftMessageServiceIT.java
@@ -30,7 +30,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(properties = "spring.profiles.active=testing")
 public class DraftMessageServiceIT {
 
-  public static final String ENC_PREFIX = "enc.";
   @Autowired
   private DraftMessageService draftMessageService;
 
@@ -42,10 +41,10 @@ public class DraftMessageServiceIT {
 
   @Before
   public void setup() throws CustomCryptoException {
-    doAnswer(encryptArgs -> ENC_PREFIX + encryptArgs.getArguments()[0]).when(encryptionService)
+    doAnswer(encryptArgs -> encryptArgs.getArguments()[0]).when(encryptionService)
         .encrypt(anyString(), anyString());
-    doAnswer(decryptArgs -> String.valueOf(decryptArgs.getArguments()[0]).substring(ENC_PREFIX.length())).when(
-        encryptionService).decrypt(anyString(), anyString());
+    doAnswer(decryptArgs -> String.valueOf(decryptArgs.getArguments()[0])).when(encryptionService)
+        .decrypt(anyString(), anyString());
     when(this.authenticatedUser.getUserId()).thenReturn("userId");
   }
 


### PR DESCRIPTION
* There is a RocketChat message payload size limit. Additional backend encryption of already end-to-end encrypted messages increases the size of the message unnecessarily